### PR TITLE
Remove sendfile.h to fix non-Linux builds

### DIFF
--- a/fdbclient/MultiVersionTransaction.actor.cpp
+++ b/fdbclient/MultiVersionTransaction.actor.cpp
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 
-#include <sys/sendfile.h>
 #include <limits.h>
 
 #include "fdbclient/MultiVersionTransaction.h"


### PR DESCRIPTION
Remove sendfile.h to fix non-Linux builds on PRB